### PR TITLE
Feature/sfat 191 nft

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -1,0 +1,33 @@
+#########################################################
+# Environment: NFT (Non Functional Testing)
+#
+# Deploy SCALE resources
+#########################################################
+terraform {
+  backend "s3" {
+    bucket         = "scale-terraform-state"
+    key            = "ccs-scale-infra-services-shared-nft"
+    region         = "eu-west-2"
+    dynamodb_table = "scale_terraform_state_lock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "eu-west-2"
+}
+
+locals {
+  environment = "NFT"
+}
+
+data "aws_ssm_parameter" "aws_account_id" {
+  name = "account-id-${lower(local.environment)}"
+}
+
+module "deploy" {
+  source         = "../../modules/configs/deploy-all"
+  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
+  environment    = local.environment
+}

--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -27,7 +27,9 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source         = "../../modules/configs/deploy-all"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
+  source            = "../../modules/configs/deploy-all"
+  aws_account_id    = data.aws_ssm_parameter.aws_account_id.value
+  environment       = local.environment
+  agreements_cpu    = 1024
+  agreements_memory = 2048
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -66,6 +66,8 @@ module "agreements" {
   ecs_security_group_id        = module.ecs.ecs_security_group_id
   ecs_task_execution_arn       = module.ecs.ecs_task_execution_arn
   ecs_cluster_id               = module.ecs.ecs_cluster_id
+  agreements_cpu               = var.agreements_cpu
+  agreements_memory            = var.agreements_memory
 }
 
 module "api-deployment" {

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -5,3 +5,13 @@ variable "aws_account_id" {
 variable "environment" {
   type = string
 }
+
+variable "agreements_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "agreements_memory" {
+  type    = number
+  default = 1024
+}

--- a/terraform/modules/services/agreements/ecs.tf
+++ b/terraform/modules/services/agreements/ecs.tf
@@ -69,8 +69,8 @@ resource "aws_ecs_task_definition" "agreements" {
   family                   = "agreements"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = var.agreements_cpu
+  memory                   = var.agreements_memory
   execution_role_arn       = var.ecs_task_execution_arn
 
   container_definitions = <<DEFINITION
@@ -79,8 +79,8 @@ resource "aws_ecs_task_definition" "agreements" {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_Agreements",
         "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/agreements-service:947c9b5-candidate",
         "requires_compatibilities": "FARGATE",
-        "cpu": 256,
-        "memory": 512,
+        "cpu": ${var.agreements_cpu},
+        "memory": ${var.agreements_memory},
         "essential": true,
         "networkMode": "awsvpc",
         "portMappings": [

--- a/terraform/modules/services/agreements/variables.tf
+++ b/terraform/modules/services/agreements/variables.tf
@@ -49,3 +49,11 @@ variable "lb_private_dns" {
 variable "environment" {
   type = string
 }
+
+variable "agreements_cpu" {
+  type = number
+}
+
+variable "agreements_memory" {
+  type = number
+}


### PR DESCRIPTION
This (and `ccs-scale-infra-services-fat`) are the ones that need a bit more thought - in relation to cpu & memory requirements at container/task level. Som's infra document doesn't go to that level of detail. I assume they are the same here (maybe a bit more complex on Decision Tree - where we have 2 containers in a task). 