### PR TITLE
Feature/sfat 123 api keys

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -89,6 +89,8 @@ module "api-deployment" {
   source            = "../../services/api-deployment"
   environment       = var.environment
   scale_rest_api_id = module.api.scale_rest_api_id
+  api_rate_limit    = var.api_rate_limit
+  api_burst_limit   = var.api_burst_limit
 
   // Simulate depends_on:
   agreements_api_gateway_integration = module.agreements.agreements_api_gateway_integration

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -15,3 +15,13 @@ variable "agreements_memory" {
   type    = number
   default = 1024
 }
+
+variable "api_rate_limit" {
+  type    = number
+  default = 10000
+}
+
+variable "api_burst_limit" {
+  type    = number
+  default = 5000
+}

--- a/terraform/modules/services/agreements/api.tf
+++ b/terraform/modules/services/agreements/api.tf
@@ -26,10 +26,11 @@ module "agreements_cors" {
 }
 
 resource "aws_api_gateway_method" "agreements_proxy" {
-  rest_api_id   = var.scale_rest_api_id
-  resource_id   = aws_api_gateway_resource.agreements_proxy.id
-  http_method   = "ANY"
-  authorization = "NONE"
+  rest_api_id      = var.scale_rest_api_id
+  resource_id      = aws_api_gateway_resource.agreements_proxy.id
+  http_method      = "ANY"
+  authorization    = "NONE"
+  api_key_required = true
 
   request_parameters = {
     "method.request.path.proxy" = false

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -65,12 +65,6 @@ resource "aws_api_gateway_usage_plan" "default" {
     stage  = aws_api_gateway_stage.shared.stage_name
   }
 
-  #quota_settings {
-  #  limit  = 20
-  #  offset = 2
-  #  period = "WEEK"
-  #}
-
   throttle_settings {
     rate_limit  = var.api_rate_limit
     burst_limit = var.api_burst_limit

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -113,3 +113,9 @@ resource "aws_api_gateway_usage_plan_key" "bat_developers" {
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }
+
+resource "aws_ssm_parameter" "fat_buyer_ui_api_key" {
+  name  = "${lower(var.environment)}-fat-buyer-ui-shared-api-key"
+  type  = "String"
+  value = aws_api_gateway_api_key.fat_buyer_ui.value
+}

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -75,19 +75,19 @@ resource "aws_api_gateway_usage_plan" "default" {
 # API Keys
 #########################################################
 resource "aws_api_gateway_api_key" "fat_buyer_ui" {
-  name = "FaT Buyer UI API Key"
+  name = "FaT Buyer UI API Key (Shared)"
 }
 
 resource "aws_api_gateway_api_key" "fat_testers" {
-  name = "FaT Testers API Key"
+  name = "FaT Testers API Key (Shared)"
 }
 
 resource "aws_api_gateway_api_key" "fat_developers" {
-  name = "FaT Developers API Key"
+  name = "FaT Developers API Key (Shared)"
 }
 
 resource "aws_api_gateway_api_key" "bat_developers" {
-  name = "BaT Developers API Key"
+  name = "BaT Developers API Key (Shared)"
 }
 
 resource "aws_api_gateway_usage_plan_key" "fat_buyer_ui" {
@@ -115,7 +115,8 @@ resource "aws_api_gateway_usage_plan_key" "bat_developers" {
 }
 
 resource "aws_ssm_parameter" "fat_buyer_ui_api_key" {
-  name  = "${lower(var.environment)}-fat-buyer-ui-shared-api-key"
-  type  = "String"
-  value = aws_api_gateway_api_key.fat_buyer_ui.value
+  name        = "${lower(var.environment)}-fat-buyer-ui-shared-api-key"
+  description = "API Key for FaT Buyer UI component to use to access the Shared API (Agreements Service)"
+  type        = "String"
+  value       = aws_api_gateway_api_key.fat_buyer_ui.value
 }

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -74,32 +74,42 @@ resource "aws_api_gateway_usage_plan" "default" {
 #########################################################
 # API Keys
 #########################################################
-resource "aws_api_gateway_api_key" "buyer_ui" {
-  name = "Buyer UI API Key"
+resource "aws_api_gateway_api_key" "fat_buyer_ui" {
+  name = "FaT Buyer UI API Key"
 }
 
-resource "aws_api_gateway_api_key" "testers" {
-  name = "Testers API Key"
+resource "aws_api_gateway_api_key" "fat_testers" {
+  name = "FaT Testers API Key"
 }
 
-resource "aws_api_gateway_api_key" "developers" {
-  name = "Developers API Key"
+resource "aws_api_gateway_api_key" "fat_developers" {
+  name = "FaT Developers API Key"
 }
 
-resource "aws_api_gateway_usage_plan_key" "buyer_ui" {
-  key_id        = aws_api_gateway_api_key.buyer_ui.id
+resource "aws_api_gateway_api_key" "bat_developers" {
+  name = "BaT Developers API Key"
+}
+
+resource "aws_api_gateway_usage_plan_key" "fat_buyer_ui" {
+  key_id        = aws_api_gateway_api_key.fat_buyer_ui.id
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }
 
-resource "aws_api_gateway_usage_plan_key" "testers" {
-  key_id        = aws_api_gateway_api_key.testers.id
+resource "aws_api_gateway_usage_plan_key" "fat_testers" {
+  key_id        = aws_api_gateway_api_key.fat_testers.id
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }
 
-resource "aws_api_gateway_usage_plan_key" "developers" {
-  key_id        = aws_api_gateway_api_key.developers.id
+resource "aws_api_gateway_usage_plan_key" "fat_developers" {
+  key_id        = aws_api_gateway_api_key.fat_developers.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
+}
+
+resource "aws_api_gateway_usage_plan_key" "bat_developers" {
+  key_id        = aws_api_gateway_api_key.bat_developers.id
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.default.id
 }

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -1,7 +1,12 @@
-variable "scale_rest_api_id" {
-  type = string
-}
+#########################################################
+# Service: API Deployments
+#
+# Creates Usage Plan/API Keys and deployment.
+#########################################################
 
+#########################################################
+# Deployment
+#########################################################
 resource "aws_api_gateway_deployment" "shared" {
   description = "Deployed at ${timestamp()}"
   rest_api_id = var.scale_rest_api_id
@@ -46,4 +51,61 @@ resource "aws_ssm_parameter" "api_invoke_url" {
   name  = "${lower(var.environment)}-agreements-service-root-url"
   type  = "String"
   value = aws_api_gateway_stage.shared.invoke_url
+}
+
+#########################################################
+# Usage Plans
+#########################################################
+resource "aws_api_gateway_usage_plan" "default" {
+  name        = "default-usage-plan"
+  description = "Default Usage Plan"
+
+  api_stages {
+    api_id = var.scale_rest_api_id
+    stage  = aws_api_gateway_stage.shared.stage_name
+  }
+
+  #quota_settings {
+  #  limit  = 20
+  #  offset = 2
+  #  period = "WEEK"
+  #}
+
+  throttle_settings {
+    rate_limit  = var.api_rate_limit
+    burst_limit = var.api_burst_limit
+  }
+}
+
+#########################################################
+# API Keys
+#########################################################
+resource "aws_api_gateway_api_key" "buyer_ui" {
+  name = "Buyer UI API Key"
+}
+
+resource "aws_api_gateway_api_key" "testers" {
+  name = "Testers API Key"
+}
+
+resource "aws_api_gateway_api_key" "developers" {
+  name = "Developers API Key"
+}
+
+resource "aws_api_gateway_usage_plan_key" "buyer_ui" {
+  key_id        = aws_api_gateway_api_key.buyer_ui.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
+}
+
+resource "aws_api_gateway_usage_plan_key" "testers" {
+  key_id        = aws_api_gateway_api_key.testers.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
+}
+
+resource "aws_api_gateway_usage_plan_key" "developers" {
+  key_id        = aws_api_gateway_api_key.developers.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.default.id
 }

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -2,6 +2,18 @@ variable "environment" {
   type = string
 }
 
+variable "scale_rest_api_id" {
+  type = string
+}
+
 variable "agreements_api_gateway_integration" {
   type = string
+}
+
+variable "api_rate_limit" {
+  type = number
+}
+
+variable "api_burst_limit" {
+  type = number
 }


### PR DESCRIPTION
This will:
* Create API Keys for BuyerUI, Developers & Testers to use
* I've set Rate/Burst limits - I've set them to what the defaults are if they are not set. I was in two minds whether to remove - but having this lets us override them if needed. Maybe unnecessary complexity though as we have no requirements in this area. Happy to remove.
* I didn't bother with quota settings

Once this is ok - I will replicate on `ccs-scale-fat-services`