### PR TITLE
SFC-800 - updated DB connection string to improve failover

### DIFF
--- a/terraform/modules/services/agreements/ecs.tf
+++ b/terraform/modules/services/agreements/ecs.tf
@@ -110,7 +110,7 @@ resource "aws_ecs_task_definition" "agreements" {
         "environment" : [
           {
           "name": "spring.datasource.url",
-          "value": "jdbc:postgresql://${var.agreements_db_endpoint}:5432/agreements"
+          "value": "jdbc:postgresql://${var.agreements_db_endpoint}:5432/agreements?connectTimeout=2&cancelSignalTimeout=2&socketTimeout=60&targetServerType=preferSlave"
           }
         ]
       }


### PR DESCRIPTION
Same change as GuidedMatch - but 'preferSlave' should make it choose a Reader instance to failover to (which is what it is configured with out of the gates) - otherwise it may failover to a Writer