### PR TITLE
SFAT-308 - task count alarm was using wrong statistic

### DIFF
--- a/terraform/modules/cw-alarms/main.tf
+++ b/terraform/modules/cw-alarms/main.tf
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "task" {
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
   period                    = "60"
-  statistic                 = "Average"
+  statistic                 = "SampleCount"
   threshold                 = var.ecs_expected_task_count
   alarm_description         = "This metric monitors task removals"
   insufficient_data_actions = []


### PR DESCRIPTION
Noticed was using Average instead of SampleCount to determine if alarm should trigger if task number dipped (would never trigger in this case)