### PR TITLE
SFAT-314 - standardise the way we to ref docker images across projects

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -84,6 +84,7 @@ module "agreements" {
   agreements_db_password_arn   = data.aws_ssm_parameter.agreements_db_password.arn
   agreements_cpu               = var.agreements_cpu
   agreements_memory            = var.agreements_memory
+  ecr_image_id_agreements      = var.ecr_image_id_agreements
 }
 
 module "api-deployment" {

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -6,6 +6,11 @@ variable "environment" {
   type = string
 }
 
+variable "ecr_image_id_agreements" {
+  type    = string
+  default = "5c8ea7b-candidate"
+}
+
 variable "agreements_cpu" {
   type    = number
   default = 512

--- a/terraform/modules/services/agreements/ecs.tf
+++ b/terraform/modules/services/agreements/ecs.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "agreements" {
     [
       {
         "name": "SCALE-EU2-${upper(var.environment)}-APP-ECS_TaskDef_Agreements",
-        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/agreements-service:5c8ea7b-candidate",
+        "image": "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/agreements-service:${var.ecr_image_id_agreements}",
         "requires_compatibilities": "FARGATE",
         "cpu": ${var.agreements_cpu},
         "memory": ${var.agreements_memory},

--- a/terraform/modules/services/agreements/variables.tf
+++ b/terraform/modules/services/agreements/variables.tf
@@ -69,3 +69,7 @@ variable "agreements_cpu" {
 variable "agreements_memory" {
   type = number
 }
+
+variable "ecr_image_id_agreements" {
+  type = string
+}


### PR DESCRIPTION
Just thinking ahead to handover to devs - thought it would be easier to explain/document if the place to update the docker image versions was consistent across services/projects - i.e. `configs/deploy-all/main.tf` (and having it here allows for environment specific overrides - if that's ever needed)