### PR TITLE
Make API Gateway private accessible via VPC link

### DIFF
--- a/terraform/modules/api/outputs.tf
+++ b/terraform/modules/api/outputs.tf
@@ -9,3 +9,7 @@ output "scale_rest_api_execution_arn" {
 output "parent_resource_id" {
   value = aws_api_gateway_resource.scale.id
 }
+
+output "scale_rest_api_policy_json" {
+  value = data.aws_iam_policy_document.rest_api_allow_vpc.json
+}

--- a/terraform/modules/api/variables.tf
+++ b/terraform/modules/api/variables.tf
@@ -1,3 +1,7 @@
 variable "environment" {
   type = string
 }
+
+variable "vpc_id" {
+  type = string
+}

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -62,6 +62,7 @@ module "ecs" {
 module "api" {
   source      = "../../api"
   environment = var.environment
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
 }
 
 module "agreements" {
@@ -95,6 +96,7 @@ module "api-deployment" {
   api_rate_limit               = var.api_rate_limit
   api_burst_limit              = var.api_burst_limit
   api_gw_log_retention_in_days = var.api_gw_log_retention_in_days
+  scale_rest_api_policy_json   = module.api.scale_rest_api_policy_json
 
   // Simulate depends_on:
   agreements_api_gateway_integration = module.agreements.agreements_api_gateway_integration

--- a/terraform/modules/services/agreements/ecs.tf
+++ b/terraform/modules/services/agreements/ecs.tf
@@ -18,11 +18,6 @@ resource "aws_lb_target_group" "target_group_9010" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
-  }
-
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -15,6 +15,10 @@ resource "aws_api_gateway_deployment" "shared" {
     var.agreements_api_gateway_integration
   ]
 
+  triggers = {
+    redeployment = sha1(var.scale_rest_api_policy_json)
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -21,3 +21,7 @@ variable "api_burst_limit" {
 variable "api_gw_log_retention_in_days" {
   type = number
 }
+
+variable "scale_rest_api_policy_json" {
+  type = string
+}


### PR DESCRIPTION
Same as https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-fat/pull/154, only in this case we _can_ remove the egress to 0.0.0.0/0!