### PR TITLE
Remove ECS SG egress and revert to EDGE API Gateway type

### DIFF
--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -1,7 +1,7 @@
 #########################################################
 # Infrastructure: API
 #
-# Deploy API Gateway account level resources. 
+# Deploy API Gateway account level resources.
 # API Deployments are done later, after services.
 #########################################################
 module "globals" {
@@ -68,6 +68,10 @@ EOF
 resource "aws_api_gateway_rest_api" "scale" {
   name        = "SCALE:EU2:${upper(var.environment)}:API:Shared"
   description = "SCALE API Gateway"
+
+  endpoint_configuration {
+    types = ["EDGE"]
+  }
 
   tags = {
     Project     = module.globals.project_name

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -7,6 +7,16 @@ module "globals" {
   source = "../globals"
 }
 
+data "aws_vpc_endpoint" "ecr" {
+  vpc_id       = var.vpc_id
+  service_name = "com.amazonaws.eu-west-2.ecr.dkr"
+}
+
+data "aws_vpc_endpoint" "s3" {
+  vpc_id       = var.vpc_id
+  service_name = "com.amazonaws.eu-west-2.s3"
+}
+
 resource "aws_ecs_cluster" "scale" {
   name = "SCALE-EU2-${upper(var.environment)}-APP-ECS_Shared"
 
@@ -38,11 +48,15 @@ resource "aws_security_group" "allow_http" {
     cidr_blocks = [var.cidr_block_vpc]
   }
 
+  # Allow traffic to/from ECR and S3 endpoints via VPC link
+  # https://7thzero.com/blog/limiting-outbound-egress-traffic-while-using-aws-fargate-and-ecr
   egress {
-    from_port   = 0
-    to_port     = 65535
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = data.aws_vpc_endpoint.ecr.security_group_ids # SG ID of VPC ECR endpoint
+    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]    # Prefix list ID of S3 endpoint
+    cidr_blocks     = [var.cidr_block_vpc]
   }
 
   tags = {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -48,6 +48,13 @@ resource "aws_security_group" "allow_http" {
     cidr_blocks = [var.cidr_block_vpc]
   }
 
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.cidr_block_vpc]
+  }
+
   # Allow traffic to/from ECR and S3 endpoints via VPC link
   # https://7thzero.com/blog/limiting-outbound-egress-traffic-while-using-aws-fargate-and-ecr
   egress {

--- a/terraform/modules/services/agreements/ecs.tf
+++ b/terraform/modules/services/agreements/ecs.tf
@@ -18,11 +18,6 @@ resource "aws_lb_target_group" "target_group_9010" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
-  }
-
   tags = {
     Project     = module.globals.project_name
     Environment = upper(var.environment)


### PR DESCRIPTION
Unfortunately required a targeted destroy of the API gateway REST API resource first - cannot change from "PRIVATE" to "EDGE" 😞 

Will need to run the same for infra-services-fat and on TST and PPD for both prior to deployment then update CCS web team with new URL and Postman environments..

```
terraform destroy -target module.deploy.module.api.aws_api_gateway_rest_api.scale
```