### PR TITLE
Restrict access to FaT REST API to VPC, NAT and external ranges

### DIFF
--- a/terraform/modules/api/outputs.tf
+++ b/terraform/modules/api/outputs.tf
@@ -9,3 +9,7 @@ output "scale_rest_api_execution_arn" {
 output "parent_resource_id" {
   value = aws_api_gateway_resource.scale.id
 }
+
+output "scale_rest_api_policy_json" {
+  value = data.aws_iam_policy_document.scale.json
+}

--- a/terraform/modules/api/variables.tf
+++ b/terraform/modules/api/variables.tf
@@ -1,3 +1,7 @@
 variable "environment" {
   type = string
 }
+
+variable "cidr_blocks_allowed_external_api_gateway" {
+  type = list
+}

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -52,6 +52,26 @@ data "aws_ssm_parameter" "cidr_block_vpc" {
   name = "${lower(var.environment)}-cidr-block-vpc"
 }
 
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_api_gateway" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-api-gateway"
+}
+
+# Get the public IP values for NAT/GW to add to the API gateway allowed list
+data "aws_ssm_parameter" "nat_eip_ids" {
+  name = "${lower(var.environment)}-eip-ids-nat-gateway"
+}
+
+data "aws_eip" "nat_eips" {
+  for_each = toset(split(",", data.aws_ssm_parameter.nat_eip_ids.value))
+
+  id = each.key
+}
+
+locals {
+  # Normalised CIDR blocks (accounting for 'none' i.e. "-" as value in SSM parameter)
+  cidr_blocks_allowed_external_api_gateway = data.aws_ssm_parameter.cidr_blocks_allowed_external_api_gateway.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_api_gateway.value) : []
+}
+
 module "ecs" {
   source         = "../../ecs"
   vpc_id         = data.aws_ssm_parameter.vpc_id.value
@@ -62,6 +82,9 @@ module "ecs" {
 module "api" {
   source      = "../../api"
   environment = var.environment
+
+  # Allow traffic from VPC, NAT and environment specific CIDR ranges (e.g. CCS, CCS web infra etc)
+  cidr_blocks_allowed_external_api_gateway = concat(tolist([data.aws_ssm_parameter.cidr_block_vpc.value]), values(data.aws_eip.nat_eips)[*].public_ip, local.cidr_blocks_allowed_external_api_gateway)
 }
 
 module "agreements" {
@@ -95,6 +118,7 @@ module "api-deployment" {
   api_rate_limit               = var.api_rate_limit
   api_burst_limit              = var.api_burst_limit
   api_gw_log_retention_in_days = var.api_gw_log_retention_in_days
+  scale_rest_api_policy_json   = module.api.scale_rest_api_policy_json
 
   // Simulate depends_on:
   agreements_api_gateway_integration = module.agreements.agreements_api_gateway_integration

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -15,6 +15,10 @@ resource "aws_api_gateway_deployment" "shared" {
     var.agreements_api_gateway_integration
   ]
 
+  triggers = {
+    redeployment = sha1(var.scale_rest_api_policy_json)
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/services/api-deployment/variables.tf
+++ b/terraform/modules/services/api-deployment/variables.tf
@@ -21,3 +21,7 @@ variable "api_burst_limit" {
 variable "api_gw_log_retention_in_days" {
   type = number
 }
+
+variable "scale_rest_api_policy_json" {
+  type = string
+}


### PR DESCRIPTION
Same as https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-fat/pull/158 - applied to SBX2.