### PR TITLE
Allow 0.0.0.0/0 Outbound for GM

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -65,6 +65,13 @@ resource "aws_security_group" "allow_http" {
     prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]    # Prefix list ID of S3 endpoint
     cidr_blocks     = [var.cidr_block_vpc]
   }
+  
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   tags = {
     Project     = module.globals.project_name


### PR DESCRIPTION
This is to prevent GM breaking on every deployment, this matches the current security group manual changes made every deployment. Once the end point IP can be identified we can further secure the outbound ports if needed