### PR TITLE
Revert "Agreements Service needs to use a AS specific Rollbar ID"

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -57,7 +57,7 @@ data "aws_ssm_parameter" "cidr_blocks_allowed_external_api_gateway" {
 }
 
 data "aws_ssm_parameter" "rollbar_access_token" {
-  name = "${lower(var.environment)}-agreements-rollbar-access-token"
+  name = "${lower(var.environment)}-rollbar-access-token"
 }
 
 data "aws_ssm_parameter" "wordpress_root_url" {


### PR DESCRIPTION
Reverting, to confirm this then fixes the build, then we can investigate a different approach to this change