### PR TITLE
Update pipeline to use JDK 17

### DIFF
--- a/terraform/agreements_service_release_pipeline/modules/agreements_service_ecr_build/buildspec.yml
+++ b/terraform/agreements_service_release_pipeline/modules/agreements_service_ecr_build/buildspec.yml
@@ -14,7 +14,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: openjdk17
       docker: 18
     commands:
       - export RELEASE_TAG="${ENVIRONMENT}-release-${CODEBUILD_BUILD_NUMBER}"


### PR DESCRIPTION
This needs to be done to support the upgrade to Spring Boot 3